### PR TITLE
Adjust push workflow to zip artifacts and publish release

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,22 +63,39 @@ jobs:
           pattern: artifacts-*
           merge-multiple: true
 
-      - shell: bash
+      - name: Prepare esp32-arduino-libs archive
+        id: prepare_archive
+        shell: bash
         run: |
+          set -euo pipefail
           mkdir -p out
           find dist -name 'arduino-esp32-libs-esp*.tar.gz' -exec tar zxvf {} -C out \;
-          cd out/tools/esp32-arduino-libs && tar zcf ../../../dist/esp32-arduino-libs.tar.gz * && cd ../../..
+          timestamp=$(date '+%Y%m%d-%H%M%S')
+          archive_name="esp32-arduino-libs-${timestamp}.zip"
+          archive_path="dist/${archive_name}"
+          (
+            cd out/tools/esp32-arduino-libs
+            zip -r "../../../${archive_path}" .
+          )
           cp out/package_esp32_index.template.json dist/package_esp32_index.template.json
+          echo "archive_name=${archive_name}" >> "${GITHUB_OUTPUT}"
+          echo "archive_path=${archive_path}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload full esp32-arduino-libs archive
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: esp32-arduino-libs
-          path: dist/esp32-arduino-libs.tar.gz
+          path: ${{ steps.prepare_archive.outputs.archive_path }}
 
       - name: Upload package_esp32_index.template.json
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package-esp32-index-json
           path: dist/package_esp32_index.template.json
+
+      - name: Upload archive to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: idf-release_v5.5
+          files: ${{ steps.prepare_archive.outputs.archive_path }}
 


### PR DESCRIPTION
## Summary
- create a timestamped ZIP archive when combining esp32-arduino-libs artifacts
- upload the archive to workflow artifacts and attach it to the idf-release_v5.5 release tag

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_e_68cd826a4c44832cbfefa25d929486cd